### PR TITLE
Adjust TermTableSeeder to generate 15 years ahead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=8RfK8cNCdlFCkWWispRso9GmwDWwaScz
+APP_KEY=SomeRandomString
 
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=8RfK8cNCdlFCkWWispRso9GmwDWwaScz
 
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/database/seeds/TermTableSeeder.php
+++ b/database/seeds/TermTableSeeder.php
@@ -13,7 +13,7 @@ class TermTableSeeder extends Seeder
      */
     public function run()
     {
-        foreach(range(2015, 50) as $year) {
+        foreach(range(2015, 2030) as $year) {
             DB::table('terms')->insert([
                 'name' => 'Fall',
                 'year' => $year


### PR DESCRIPTION
A bug in TermTableSeeder was causing seed data to be generated from 2015 back until the year 50. This fix changes that so the data is generated from 2015 until 2030.