### PR TITLE
Adjust TermTableSeeder to generate 15 years ahead

### DIFF
--- a/database/seeds/TermTableSeeder.php
+++ b/database/seeds/TermTableSeeder.php
@@ -13,7 +13,7 @@ class TermTableSeeder extends Seeder
      */
     public function run()
     {
-        foreach(range(2015, 50) as $year) {
+        foreach(range(2015, 2030) as $year) {
             DB::table('terms')->insert([
                 'name' => 'Fall',
                 'year' => $year


### PR DESCRIPTION
A bug in TermTableSeeder was causing the years 50 to 2015 to be generated. This fix changes that, so the years 2015 to 2030 are created instead.