### PR TITLE
Fix typo in API root route definition

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -29,7 +29,7 @@ Route::group(['middleware' => 'csrf', 'prefix' => 'api'], function () {
                 'members_url' => '/members',
                 'memberships_url' => '/memberships',
                 'mentors_url' => '/mentors',
-                'officesr' => '/officers',
+                'officers_url' => '/officers',
                 'quotes_url' => '/quotes',
                 'terms_url' => '/terms',
             ]);


### PR DESCRIPTION
This is a correction of a misspelling of 'officers_url' in routes.php.