### PR TITLE
Use 'url' attributes instead of raw relation ids

### DIFF
--- a/app/AgendaItem.php
+++ b/app/AgendaItem.php
@@ -10,6 +10,8 @@ class AgendaItem extends Model
     use SoftDeletes;
 
     protected $appends = [
+        'author_url',
+        'edited_by_url',
         'url',
     ];
 
@@ -22,8 +24,11 @@ class AgendaItem extends Model
     ];
 
     protected $hidden = [
+        'author',
         'created_at',
+        'created_by',
         'deleted_at',
+        'edited_by',
         'updated_at',
         'updated_by',
     ];
@@ -36,6 +41,16 @@ class AgendaItem extends Model
     public function edited_by()
     {
         return $this->belongsTo('App\Member', 'updated_by');
+    }
+
+    public function getAuthorUrlAttribute()
+    {
+        return $this->author->url;
+    }
+
+    public function getEditedByUrlAttribute()
+    {
+        return $this->edited_by ? $this->edited_by->url : null;
     }
 
     public function getUrlAttribute()

--- a/app/Group.php
+++ b/app/Group.php
@@ -9,12 +9,18 @@ class Group extends Model
 {
     use SoftDeletes;
 
-    protected $appends = ['head_url', 'url'];
+    protected $appends = [
+        'head_url',
+        'members_url',
+        'url',
+    ];
 
     protected $hidden = [
         'created_at',
         'deleted_at',
         'head',
+        'head_id',
+        'members',
         'updated_at',
     ];
 
@@ -39,6 +45,11 @@ class Group extends Model
     public function getHeadUrlAttribute()
     {
         return $this->head->url;
+    }
+
+    public function getMembersUrlAttribute()
+    {
+        return '/members?group=' . $this->id;
     }
 
     public function getUrlAttribute()

--- a/app/Lingo.php
+++ b/app/Lingo.php
@@ -12,7 +12,9 @@ class Lingo extends Model
 {
     use SoftDeletes;
 
-    protected $appends = ['url'];
+    protected $appends = [
+        'url',
+    ];
 
     protected $table = 'lingo';
 

--- a/app/Link.php
+++ b/app/Link.php
@@ -9,6 +9,11 @@ class Link extends Model
 {
     use SoftDeletes;
 
+    protected $appends = [
+        'creator_url',
+        'url',
+    ];
+
     protected $dates = [
         'deleted_at',
     ];
@@ -20,6 +25,7 @@ class Link extends Model
 
     protected $hidden = [
         'created_at',
+        'creator',
         'deleted_at',
         'updated_at',
     ];
@@ -27,6 +33,11 @@ class Link extends Model
     public function creator()
     {
         return $this->belongsTo('App\Member');
+    }
+
+    public function getCreatorUrlAttribute()
+    {
+        return $this->creator->url;
     }
 
     public function getUrlAttribute()

--- a/app/Member.php
+++ b/app/Member.php
@@ -12,11 +12,17 @@ class Member extends Model
 {
     use SoftDeletes;
 
-    protected $appends = ['url'];
+    protected $appends = [
+        'groups_url',
+        'memberships_url',
+        'url',
+    ];
 
     protected $hidden = [
         'created_at',
         'deleted_at',
+        'groups',
+        'memberships',
         'updated_at',
     ];
 
@@ -55,6 +61,22 @@ class Member extends Model
     {
         return $this->hasMany('App\Membership');
     }
+
+    /**
+     * IETF url getter.
+     */
+    public function getGroupsUrlAttribute()
+    {
+        return '/groups?member=' . $this->id;
+    }   
+
+    /**
+     * IETF url getter.
+     */
+    public function getMembershipsUrlAttribute()
+    {
+        return '/memberships?member=' . $this->id;
+    }   
 
     /**
      * IETF url getter.

--- a/app/Membership.php
+++ b/app/Membership.php
@@ -12,12 +12,19 @@ class Membership extends Model
 {
     use SoftDeletes;
 
-    protected $appends = ['url'];
+    protected $appends = [
+        'member_url',
+        'term_url',
+        'url',
+    ];
 
     protected $hidden = [
-        'member_id',
         'created_at',
         'deleted_at',
+        'member',
+        'member_id',
+        'term',
+        'term_id',
         'updated_at',
     ];
 
@@ -39,6 +46,16 @@ class Membership extends Model
     public function term()
     {
         return $this->belongsTo('App\Term');
+    }
+
+    public function getMemberUrlAttribute()
+    {
+        return $this->member->url;
+    }
+
+    public function getTermUrlAttribute()
+    {
+        return $this->term->url;
     }
 
     public function getUrlAttribute()

--- a/app/Officer.php
+++ b/app/Officer.php
@@ -14,13 +14,19 @@ class Officer extends Model
 
     protected $appends = [
         'email',
+        'member_url',
         'position',
+        'term_url',
         'url',
     ];
 
     protected $hidden = [
         'created_at',
         'deleted_at',
+        'member',
+        'member_id',
+        'term',
+        'term_id',
         'updated_at',
     ];
 
@@ -56,6 +62,16 @@ class Officer extends Model
     public function getPositionAttribute()
     {
         return str_replace(' ', '_', strtolower($this->title));
+    }
+
+    public function getMemberUrlAttribute()
+    {
+        return $this->member->url;
+    }
+
+    public function getTermUrlAttribute()
+    {
+        return $this->term->url;
     }
 
     public function getUrlAttribute()

--- a/app/Term.php
+++ b/app/Term.php
@@ -11,7 +11,9 @@ class Term extends Model
 {
     public $timestamps = false;
 
-    protected $appends = ['url'];
+    protected $appends = [
+        'url'
+    ];
 
     protected $fillable = [
         'name',

--- a/app/Tip.php
+++ b/app/Tip.php
@@ -11,12 +11,18 @@ class Tip extends Model
 {
     use SoftDeletes;
 
-    protected $appends = ['url'];
+    protected $appends = [
+        'author_url',
+        'edited_by_url',
+        'url',
+    ];
 
     protected $hidden = [
+        'author',
         'created_at',
         'created_by',
         'deleted_at',
+        'edited_by',
         'updated_at',
         'updated_by',
     ];
@@ -37,6 +43,16 @@ class Tip extends Model
     public function edited_by()
     {
         return $this->belongsTo('App\Member', 'updated_by');
+    }
+
+    public function getAuthorUrlAttribute()
+    {
+        return $this->author->url;
+    }
+
+    public function getEditedByUrlAttribute()
+    {
+        return $this->edited_by ? $this->edited_by->url : null;
     }
 
     public function getUrlAttribute()


### PR DESCRIPTION
(Opening this as a PR because I want consensus on this, I do not personally feel strongly one way or another).

Example (before):
```json
[
  {
    "id": "1",
    "content": "Looking for exam resources? [...]",
    "author_id": 1,
    "edited_by_id": null,
    "url": "/tips/1"
  }
]
```

Example (after):
```json
[
  {
    "id": "1",
    "content": "Looking for exam resources? [...]",
    "author_url": "/members/1",
    "edited_by_url": null,
    "url": "/tips/1"
  }
]
```

This would certainly require more changes (and more work) on the client side of things. Also, if we want this, what is the naming convention? Do we want `author_url` or just straight `author`?